### PR TITLE
Improve OpenTelemetry logging

### DIFF
--- a/apps/chat/app/api.py
+++ b/apps/chat/app/api.py
@@ -1,11 +1,17 @@
 from fastapi import APIRouter, HTTPException, status, Depends
 from .schemas import (
-    ChatRequest, ChatResponse, Message, ChatMessage,
-    CreateProjectRequest, ProjectInfo, ChatHistory
+    ChatRequest, ChatResponse, Message,
+    CreateProjectRequest, ProjectInfo,
 )
+from .models import ChatHistory, StoredChatMessage
 from .services.chat_service import ChatService
 from .core.project_memory import ProjectMemory
-from app.logger import with_context
+import structlog
+from app.logger import enrich_context
+from opentelemetry import metrics
+
+meter = metrics.get_meter(__name__)
+chat_counter = meter.create_counter("chat_requests_total")
 import traceback
 
 api_router = APIRouter(
@@ -23,11 +29,14 @@ async def chat_endpoint(
     req: ChatRequest,
     chat_service: ChatService = Depends(get_chat_service)
 ):
-    log = with_context(
-        event="chat_api_called",
-        endpoint="/chat",
-        user_message=req.messages[-1].content if req.messages else None
+    log = structlog.get_logger("chat").bind(
+        **enrich_context(
+            event="chat_api_called",
+            endpoint="/chat",
+            user_message=req.messages[-1].content if req.messages else None,
+        )
     )
+    chat_counter.add(1, {"project_id": "default"})
 
     log.info("Received standard chat request")
 
@@ -43,16 +52,20 @@ async def chat_endpoint(
 @api_router.post("/projects", response_model=ProjectInfo)
 def create_project(req: CreateProjectRequest):
     project = memory.create_project(req.name)
-    with_context(
-        event="project_created",
-        project_id=project.id,
-        project_name=project.name
+    structlog.get_logger("chat").bind(
+        **enrich_context(
+            event="project_created",
+            project_id=project.id,
+            project_name=project.name,
+        )
     ).info("New project created")
     return project
 
 @api_router.get("/projects", response_model=list[ProjectInfo])
 def list_projects():
-    with_context(event="project_list_requested").info("Project list requested")
+    structlog.get_logger("chat").bind(
+        **enrich_context(event="project_list_requested")
+    ).info("Project list requested")
     return memory.list_projects()
 
 @api_router.post("/projects/{project_id}/chat", response_model=ChatResponse)
@@ -61,17 +74,23 @@ async def chat_in_project(
     req: ChatRequest,
     chat_service: ChatService = Depends(get_chat_service)
 ):
-    log = with_context(
-        event="project_chat_called",
-        endpoint=f"/projects/{project_id}/chat",
-        project_id=project_id,
-        user_message=req.messages[-1].content if req.messages else None
+    log = structlog.get_logger("chat").bind(
+        **enrich_context(
+            event="project_chat_called",
+            endpoint=f"/projects/{project_id}/chat",
+            project_id=project_id,
+            user_message=req.messages[-1].content if req.messages else None,
+        )
     )
+    chat_counter.add(1, {"project_id": project_id})
 
     log.info("Chat within project requested")
 
     try:
-        chat_messages = [ChatMessage(role=m.role, content=m.content) for m in req.messages]
+        chat_messages = [
+            StoredChatMessage(role=m.role, content=m.content)
+            for m in req.messages
+        ]
         memory.add_chat(project_id, chat_messages)
 
         reply = await chat_service.get_ai_reply(
@@ -90,9 +109,8 @@ async def chat_in_project(
 
 @api_router.get("/projects/{project_id}/history", response_model=list[ChatHistory])
 def get_project_history(project_id: str):
-    log = with_context(
-        event="project_history_requested",
-        project_id=project_id
+    log = structlog.get_logger("chat").bind(
+        **enrich_context(event="project_history_requested", project_id=project_id)
     )
 
     log.info("Project history requested")

--- a/apps/chat/app/core/config.py
+++ b/apps/chat/app/core/config.py
@@ -2,6 +2,9 @@ from pydantic_settings import BaseSettings
 from functools import lru_cache
 import os
 
+import structlog
+from app.logger import enrich_context
+
 class Settings(BaseSettings):
     """
     Конфиг всего приложения.
@@ -18,4 +21,8 @@ class Settings(BaseSettings):
 
 @lru_cache()
 def get_settings():
-    return Settings()
+    settings = Settings()
+    structlog.get_logger("chat").bind(
+        **enrich_context(event="config_loaded")
+    ).info("Settings loaded")
+    return settings

--- a/apps/chat/app/core/health.py
+++ b/apps/chat/app/core/health.py
@@ -1,5 +1,8 @@
 from fastapi import APIRouter
 
+import structlog
+from app.logger import enrich_context
+
 health_router = APIRouter(prefix="/health", tags=["health"])
 
 @health_router.get("", summary="Health check", response_model=dict)
@@ -7,4 +10,7 @@ async def health():
     """
     Healthcheck endpoint для мониторинга и Kubernetes/LB.
     """
+    structlog.get_logger("chat").bind(
+        **enrich_context(event="health_check")
+    ).info("Health check called")
     return {"status": "ok"}

--- a/apps/chat/app/core/project_memory.py
+++ b/apps/chat/app/core/project_memory.py
@@ -1,31 +1,65 @@
 from typing import Dict, List
-from app.schemas import ProjectInfo, CreateProjectRequest, ChatHistory, ChatMessage
+from app.schemas import ProjectInfo
+from app.models import ChatHistory, StoredChatMessage
 from uuid import uuid4
-from datetime import datetime
+
+import structlog
+from opentelemetry.trace import get_current_span
+from app.logger import enrich_context
 
 class ProjectMemory:
     def __init__(self):
         self.projects: Dict[str, ProjectInfo] = {}
         self.histories: Dict[str, List[ChatHistory]] = {}
+        structlog.get_logger("chat").bind(
+            **enrich_context(event="memory_init")
+        ).info("Project memory initialized")
 
     def create_project(self, name: str) -> ProjectInfo:
         project_id = str(uuid4())
         project = ProjectInfo(id=project_id, name=name)
         self.projects[project_id] = project
         self.histories[project_id] = []
+        structlog.get_logger("chat").bind(
+            **enrich_context(
+                event="project_created", project_id=project_id, project_name=name
+            )
+        ).info("Project created in memory")
         return project
 
     def list_projects(self) -> List[ProjectInfo]:
+        structlog.get_logger("chat").bind(
+            **enrich_context(event="projects_listed", count=len(self.projects))
+        ).info("Listing projects")
         return list(self.projects.values())
 
-    def add_chat(self, project_id: str, messages: List[ChatMessage]) -> ChatHistory:
+    def add_chat(self, project_id: str, messages: List[StoredChatMessage]) -> ChatHistory:
         if project_id not in self.projects:
+            structlog.get_logger("chat").bind(
+                **enrich_context(event="project_not_found", project_id=project_id)
+            ).warning("Attempt to add chat to missing project")
             raise ValueError(f"Проект {project_id} не найден")
-        history = ChatHistory(project_id=project_id, messages=messages)
+        span = get_current_span()
+        trace = span.get_span_context() if span else None
+        history = ChatHistory(
+            project_id=project_id,
+            messages=messages,
+            trace_id=format(trace.trace_id, "032x") if trace and trace.trace_id != 0 else None,
+            span_id=format(trace.span_id, "016x") if trace and trace.trace_id != 0 else None,
+        )
         self.histories[project_id].append(history)
+        structlog.get_logger("chat").bind(
+            **enrich_context(event="chat_saved", project_id=project_id)
+        ).info("Chat added to project")
         return history
 
     def get_project_history(self, project_id: str) -> List[ChatHistory]:
         if project_id not in self.projects:
+            structlog.get_logger("chat").bind(
+                **enrich_context(event="project_not_found", project_id=project_id)
+            ).warning("History requested for missing project")
             raise ValueError(f"Проект {project_id} не найден")
+        structlog.get_logger("chat").bind(
+            **enrich_context(event="history_retrieved", project_id=project_id)
+        ).info("Returning project history")
         return self.histories.get(project_id, [])

--- a/apps/chat/app/logger.py
+++ b/apps/chat/app/logger.py
@@ -1,35 +1,37 @@
-from loguru import logger
+import logging
 import sys
-import json
 
-def flat_json_formatter(record):
-    flat = {
-        "timestamp": record["time"].isoformat(),
-        "level": record["level"].name,
-        "message": record["message"],
-        "logger": record["name"],
-        "module": record["module"],
-        "function": record["function"],
-        "line": record["line"],
-        "event": record["extra"].get("event"),
-        "project_id": record["extra"].get("project_id"),
-        "trace_id": record["extra"].get("trace_id"),
-        "model": record["extra"].get("model"),
-        "job": record["extra"].get("job"),
-        "user_message": record["extra"].get("user_message"),
-        "ai_reply": record["extra"].get("ai_reply"),
-    }
-    return json.dumps({k: v for k, v in flat.items() if v is not None}) + "\n"
+import structlog
+from opentelemetry.trace import get_current_span
 
-# Очищаем стандартные хендлеры
-logger.remove()
 
-# ✅ Передаём через sink
-logger.add(
-    sink=lambda msg: sys.stdout.write(flat_json_formatter(msg.record)),
-    enqueue=True,
-    level="INFO",
+logging.basicConfig(stream=sys.stdout, format="%(message)s", level=logging.INFO)
+
+
+def add_trace_context(_, __, event_dict):
+    span = get_current_span()
+    if span and span.get_span_context().trace_id != 0:
+        ctx = span.get_span_context()
+        event_dict["trace_id"] = format(ctx.trace_id, "032x")
+        event_dict["span_id"] = format(ctx.span_id, "016x")
+    return event_dict
+
+structlog.configure(
+    wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+    processors=[
+        structlog.processors.TimeStamper(fmt="iso", key="timestamp"),
+        add_trace_context,
+        structlog.processors.JSONRenderer(),
+    ],
+    logger_factory=structlog.stdlib.LoggerFactory(),
 )
 
+
 def with_context(**kwargs):
-    return logger.bind(**kwargs)
+    """Return a logger pre-bound with contextual information."""
+    return structlog.get_logger("chat").bind(**kwargs)
+
+
+def enrich_context(event: str, **kwargs):
+    from .logger import with_context
+    return add_trace_context(None, None, with_context(event=event, **kwargs)._context)

--- a/apps/chat/app/logger.py
+++ b/apps/chat/app/logger.py
@@ -9,6 +9,7 @@ logging.basicConfig(stream=sys.stdout, format="%(message)s", level=logging.INFO)
 
 
 def add_trace_context(_, __, event_dict):
+    """Inject ``trace_id`` and ``span_id`` into ``event_dict`` if a span is active."""
     span = get_current_span()
     if span and span.get_span_context().trace_id != 0:
         ctx = span.get_span_context()
@@ -32,6 +33,12 @@ def with_context(**kwargs):
     return structlog.get_logger("chat").bind(**kwargs)
 
 
-def enrich_context(event: str, **kwargs):
+def enrich_context(event: str, **kwargs) -> dict:
+    """Return context with trace information for logging calls."""
     from .logger import with_context
-    return add_trace_context(None, None, with_context(event=event, **kwargs)._context)
+    return add_trace_context(
+        None,
+        None,
+        with_context(event=event, **kwargs)._context,
+    )
+

--- a/apps/chat/app/main.py
+++ b/apps/chat/app/main.py
@@ -2,6 +2,9 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .api import api_router
 from .core.health import health_router
+from .observability.tracing import setup_tracing
+import structlog
+from .logger import enrich_context
 
 def create_app() -> FastAPI:
     app = FastAPI(
@@ -20,8 +23,17 @@ def create_app() -> FastAPI:
     app.include_router(api_router)
     app.include_router(health_router)
 
+    # Настраиваем OpenTelemetry и логируем запуск
+    setup_tracing(app)
+    structlog.get_logger("chat").bind(
+        **enrich_context(event="startup")
+    ).info("Application initialized")
+
     @app.get("/")
     async def root():
+        structlog.get_logger("chat").bind(
+            **enrich_context(event="root_called")
+        ).info("Root endpoint accessed")
         return {
             "status": "ok",
             "service": app.title,
@@ -31,3 +43,7 @@ def create_app() -> FastAPI:
     return app
 
 app = create_app()
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/apps/chat/app/models.py
+++ b/apps/chat/app/models.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from uuid import uuid4
+from datetime import datetime
+
+from .schemas import Role
+
+class StoredChatMessage(BaseModel):
+    role: Role
+    content: str
+    trace_id: Optional[str] = Field(default=None, example="97f5...")
+    span_id: Optional[str] = Field(default=None, example="6b1f...")
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+class ChatHistory(BaseModel):
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    project_id: str
+    messages: List[StoredChatMessage]
+    trace_id: Optional[str] = None
+    span_id: Optional[str] = None
+    timestamp: datetime = Field(default_factory=datetime.utcnow)

--- a/apps/chat/app/observability/tracing.py
+++ b/apps/chat/app/observability/tracing.py
@@ -1,0 +1,14 @@
+from opentelemetry import trace
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+
+def setup_tracing(app) -> None:
+    resource = Resource(attributes={"service.name": "chat-api"})
+    provider = TracerProvider(resource=resource)
+    processor = BatchSpanProcessor(ConsoleSpanExporter())
+    provider.add_span_processor(processor)
+    trace.set_tracer_provider(provider)
+    FastAPIInstrumentor().instrument_app(app, tracer_provider=provider)

--- a/apps/chat/app/schemas.py
+++ b/apps/chat/app/schemas.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel, Field
 from enum import Enum
 from typing import List, Optional
 from uuid import uuid4
-from datetime import datetime
+
 
 # ----------------------------------------
 # 📌 Роли сообщений
@@ -16,36 +16,35 @@ class Role(str, Enum):
 # 📌 Базовое сообщение
 # ----------------------------------------
 class Message(BaseModel):
-    role: Role
-    content: str
+    role: Role = Field(..., example="user")
+    content: str = Field(..., example="Hello")
 
 # ----------------------------------------
 # 📌 Структура запроса и ответа чата
 # ----------------------------------------
 class ChatRequest(BaseModel):
-    messages: List[Message]
-    user_api_key: Optional[str] = None
+    messages: List[Message] = Field(..., alias="messages", example=[{"role": "user", "content": "Hi"}])
+    user_api_key: Optional[str] = Field(
+        default=None,
+        alias="userApiKey",
+        example="sk-my-key"
+    )
+
+    class Config:
+        populate_by_name = True
 
 class ChatResponse(BaseModel):
-    reply: str
+    reply: str = Field(..., example="Hello, world")
 
 # ----------------------------------------
 # 📂 Память и проекты
 # ----------------------------------------
 
-class ChatMessage(BaseModel):
-    role: Role
-    content: str
 
-class ChatHistory(BaseModel):
-    id: str = Field(default_factory=lambda: str(uuid4()))
-    project_id: str
-    messages: List[ChatMessage]
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
 
 class CreateProjectRequest(BaseModel):
-    name: str
+    name: str = Field(..., example="My Project")
 
 class ProjectInfo(BaseModel):
-    id: str = Field(default_factory=lambda: str(uuid4()))
-    name: str
+    id: str = Field(default_factory=lambda: str(uuid4()), example="123e4567-e89b-12d3-a456-426614174000")
+    name: str = Field(..., example="My Project")

--- a/apps/chat/requirements.txt
+++ b/apps/chat/requirements.txt
@@ -4,4 +4,7 @@ uvicorn
 pydantic
 python-dotenv
 pydantic-settings
-loguru
+structlog
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-instrumentation-fastapi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,10 @@ dependencies = [
   "pydantic",
   "python-dotenv",
   "pydantic-settings",
-  "python-json-logger"
+  "structlog",
+  "opentelemetry-api",
+  "opentelemetry-sdk",
+  "opentelemetry-instrumentation-fastapi"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- add trace context enrichment helper and structlog processor
- separate storage models from API schemas
- attach OpenTelemetry metrics to chat endpoints
- store trace id and span id inside project history
- migrate all logging calls to use `enrich_context`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff471d69c8330819d9a62a1d7e206