### PR TITLE
Add Notion behavior manager

### DIFF
--- a/README.v2.md
+++ b/README.v2.md
@@ -137,6 +137,7 @@ kubectl logs -n ingress-nginx -l app.kubernetes.io/name=ingress-nginx | tail -n 
 * Все изменения только через Git → CI → ArgoCD (никаких ручных `kubectl apply`).
 * Для новых секретов всегда использовать SealedSecret.
 * В случае изменений переменных окружения или конфига — просто коммит в git и Argo всё подтянет.
+* Для управления поведением агента через Notion задайте `NOTION_TOKEN` и `NOTION_PAGE_ID` в переменных окружения.
 * Для отладки — использовать логи pod-ов, а не "залезание внутрь".
 
 ---

--- a/apps/chat/app/core/config.py
+++ b/apps/chat/app/core/config.py
@@ -13,6 +13,8 @@ class Settings(BaseSettings):
     llm_api_url: str = "http://localhost:4000"
     chat_model: str = "openai/gpt-4.1"
     project_name: str = "ChatMicroservice"
+    notion_token: str = os.getenv("NOTION_TOKEN", "")
+    notion_page_id: str = os.getenv("NOTION_PAGE_ID", "")
 
     class Config:
         env_file = ".env"

--- a/apps/chat/app/integrations/behavior_manager.py
+++ b/apps/chat/app/integrations/behavior_manager.py
@@ -1,0 +1,28 @@
+import yaml
+from app.logger import enrich_context
+
+class BehaviorManager:
+    """Loads and stores agent behavior from Notion."""
+
+    def __init__(self, notion_client, page_id: str):
+        self.notion_client = notion_client
+        self.page_id = page_id
+        self.behavior = {}
+
+    async def refresh(self) -> None:
+        log = enrich_context(event="behavior_refresh", page_id=self.page_id)
+        data = await self.notion_client.fetch_page(self.page_id)
+        log.info("Behavior page retrieved")
+        try:
+            # Expect first child to be a code block with YAML
+            for block in data.get("results", []):
+                if block.get("type") == "code":
+                    text = block["code"].get("rich_text", [])
+                    content = "".join(t.get("plain_text", "") for t in text)
+                    self.behavior = yaml.safe_load(content) or {}
+                    log.bind(event="behavior_loaded").info("Behavior updated")
+                    return
+            log.bind(event="behavior_not_found").warning("No YAML code block found")
+        except Exception as e:
+            log.bind(event="behavior_parse_error", error=str(e)).error("Failed to parse behavior")
+            raise

--- a/apps/chat/app/integrations/notion_client.py
+++ b/apps/chat/app/integrations/notion_client.py
@@ -1,0 +1,26 @@
+import httpx
+from app.logger import enrich_context
+
+class NotionClient:
+    """Minimal async client to retrieve data from Notion"""
+
+    def __init__(self, token: str):
+        self.token = token
+        self.base_url = "https://api.notion.com/v1"
+        self.headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Notion-Version": "2022-06-28",
+        }
+
+    async def fetch_page(self, page_id: str) -> dict:
+        log = enrich_context(event="notion_fetch", page_id=page_id)
+        url = f"{self.base_url}/blocks/{page_id}/children"
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                resp = await client.get(url, headers=self.headers)
+                resp.raise_for_status()
+                log.info("Fetched Notion page")
+                return resp.json()
+        except Exception as e:
+            log.bind(error=str(e)).error("Failed to fetch Notion page")
+            raise

--- a/apps/chat/app/main.py
+++ b/apps/chat/app/main.py
@@ -4,12 +4,27 @@ from .api import api_router
 from .core.health import health_router
 from .observability.tracing import setup_tracing
 from .logger import enrich_context
+from .core.config import get_settings
+from .integrations.notion_client import NotionClient
+from .integrations.behavior_manager import BehaviorManager
 
 def create_app() -> FastAPI:
     app = FastAPI(
         title="Chat Microservice",
         version="0.1.0"
     )
+
+    settings = get_settings()
+
+    if settings.notion_token and settings.notion_page_id:
+        notion_client = NotionClient(settings.notion_token)
+        behavior_manager = BehaviorManager(notion_client, settings.notion_page_id)
+        app.state.behavior_manager = behavior_manager
+
+        @app.on_event("startup")
+        async def load_behavior():
+            await behavior_manager.refresh()
+
     # CORS: на проде настрой через ENV/config
     app.add_middleware(
         CORSMiddleware,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ dependencies = [
   "structlog",
   "opentelemetry-api",
   "opentelemetry-sdk",
-  "opentelemetry-instrumentation-fastapi"
+    "opentelemetry-instrumentation-fastapi"
+    ,"PyYAML"
+    ,"notion-client"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- integrate Notion-driven behaviour management via new BehaviorManager
- add NotionClient for retrieving Notion pages
- expose NOTION_TOKEN and NOTION_PAGE_ID settings
- load behaviour at startup if settings are present
- document new environment variables
- add dependencies for YAML and Notion client

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684d15832a5083309e56a043d8b7904a