### PR TITLE
Move project state to SQLModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ make test  # pytest
 make run   # запускает FastAPI
 ```
 
+### Работа с БД и миграции
+
+Используется SQLModel и PostgreSQL. URL подключения задаётся переменной `DATABASE_URL` (по умолчанию SQLite `sqlite:///db.sqlite3`).
+
+Инициализация и миграции через Alembic:
+
+```bash
+alembic init alembic      # однократная инициализация
+alembic revision --autogenerate -m "init"
+alembic upgrade head
+```
+
 ### Makefile (доступные команды):
 
 ```bash

--- a/apps/chat/app/api.py
+++ b/apps/chat/app/api.py
@@ -4,9 +4,13 @@ from .schemas import (
     CreateProjectRequest, ProjectInfo,
 )
 from .models import ChatHistory, StoredChatMessage
+from .models import Project, ChatHistoryDB
 from .integrations.behavior_manager import BehaviorManager
 from .services.chat_service import ChatService
 from .core.project_memory import ProjectMemory
+from .core.db import get_session
+from sqlmodel import Session, select
+import json
 from app.logger import enrich_context
 from opentelemetry import metrics
 from opentelemetry.trace import get_current_span
@@ -17,6 +21,7 @@ api_router = APIRouter(
     tags=["chat"]
 )
 
+# In-memory fallback (not used when database is configured)
 memory = ProjectMemory()
 meter = metrics.get_meter(__name__)
 chat_counter = meter.create_counter("chat_requests_total")
@@ -55,25 +60,33 @@ async def chat_endpoint(
         raise HTTPException(status_code=500, detail="AI сервис недоступен")
 
 @api_router.post("/projects", response_model=ProjectInfo)
-def create_project(req: CreateProjectRequest):
-    project = memory.create_project(req.name)
+def create_project(
+    req: CreateProjectRequest,
+    session: Session = Depends(get_session),
+):
+    project = Project(name=req.name)
+    session.add(project)
+    session.commit()
+    session.refresh(project)
     enrich_context(
         event="project_created",
         project_id=project.id,
         project_name=project.name
     ).info("New project created")
-    return project
+    return ProjectInfo(id=project.id, name=project.name)
 
 @api_router.get("/projects", response_model=list[ProjectInfo])
-def list_projects():
+def list_projects(session: Session = Depends(get_session)):
     enrich_context(event="project_list_requested").info("Project list requested")
-    return memory.list_projects()
+    projects = session.exec(select(Project)).all()
+    return [ProjectInfo(id=p.id, name=p.name) for p in projects]
 
 @api_router.post("/projects/{project_id}/chat", response_model=ChatResponse)
 async def chat_in_project(
     project_id: str,
     req: ChatRequest,
-    chat_service: ChatService = Depends(get_chat_service)
+    chat_service: ChatService = Depends(get_chat_service),
+    session: Session = Depends(get_session)
 ):
     log = enrich_context(
         event="project_chat_called",
@@ -94,11 +107,23 @@ async def chat_in_project(
         span_id = format(ctx.span_id, "016x")
 
     try:
+        # Ensure project exists
+        project = session.get(Project, project_id)
+        if not project:
+            raise ValueError(f"Проект {project_id} не найден")
+
         chat_messages = [
             StoredChatMessage(role=m.role, content=m.content)
             for m in req.messages
         ]
-        memory.add_chat(project_id, chat_messages, trace_id=trace_id, span_id=span_id)
+        history_db = ChatHistoryDB(
+            project_id=project_id,
+            messages=json.dumps([m.model_dump() for m in chat_messages]),
+            trace_id=trace_id,
+            span_id=span_id,
+        )
+        session.add(history_db)
+        session.commit()
 
         reply = await chat_service.get_ai_reply(
             req.messages, req.user_api_key, project_id=project_id, trace_id=trace_id
@@ -115,7 +140,10 @@ async def chat_in_project(
         raise HTTPException(status_code=500, detail="Ошибка при обращении к AI")
 
 @api_router.get("/projects/{project_id}/history", response_model=list[ChatHistory])
-def get_project_history(project_id: str):
+def get_project_history(
+    project_id: str,
+    session: Session = Depends(get_session)
+):
     log = enrich_context(
         event="project_history_requested",
         project_id=project_id
@@ -124,7 +152,26 @@ def get_project_history(project_id: str):
     log.info("Project history requested")
 
     try:
-        return memory.get_project_history(project_id)
+        project = session.get(Project, project_id)
+        if not project:
+            raise ValueError(f"Проект {project_id} не найден")
+        histories = session.exec(
+            select(ChatHistoryDB).where(ChatHistoryDB.project_id == project_id)
+        ).all()
+        result = []
+        for h in histories:
+            messages = [StoredChatMessage(**m) for m in json.loads(h.messages)]
+            result.append(
+                ChatHistory(
+                    id=h.id,
+                    project_id=h.project_id,
+                    messages=messages,
+                    trace_id=h.trace_id,
+                    span_id=h.span_id,
+                    timestamp=h.timestamp,
+                )
+            )
+        return result
     except ValueError as e:
         log.bind(event="project_history_not_found").warning("Project not found when fetching history")
         raise HTTPException(status_code=404, detail=str(e))

--- a/apps/chat/app/core/config.py
+++ b/apps/chat/app/core/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     project_name: str = "ChatMicroservice"
     notion_token: str = os.getenv("NOTION_TOKEN", "")
     notion_page_id: str = os.getenv("NOTION_PAGE_ID", "")
+    database_url: str = os.getenv("DATABASE_URL", "sqlite:///db.sqlite3")
 
     class Config:
         env_file = ".env"

--- a/apps/chat/app/core/db.py
+++ b/apps/chat/app/core/db.py
@@ -1,0 +1,14 @@
+from sqlmodel import SQLModel, create_engine, Session
+from app.core.config import get_settings
+
+DATABASE_URL = get_settings().database_url
+engine = create_engine(DATABASE_URL, echo=True)
+
+
+def init_db() -> None:
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session():
+    with Session(engine) as session:
+        yield session

--- a/apps/chat/app/main.py
+++ b/apps/chat/app/main.py
@@ -6,6 +6,7 @@ from .core.health import health_router
 from .observability.tracing import setup_tracing
 from .logger import enrich_context
 from .core.config import get_settings
+from .core.db import init_db
 from .integrations.notion_client import NotionClient
 from .integrations.behavior_manager import BehaviorManager
 
@@ -19,6 +20,10 @@ def create_app() -> FastAPI:
     )
 
     settings = get_settings()
+
+    @app.on_event("startup")
+    def _init_db() -> None:
+        init_db()
 
     if settings.notion_token and settings.notion_page_id:
         notion_client = NotionClient(settings.notion_token)

--- a/apps/chat/app/models/__init__.py
+++ b/apps/chat/app/models/__init__.py
@@ -1,6 +1,9 @@
 from .chat import StoredChatMessage, ChatHistory
+from .db_models import Project, ChatHistoryDB
 
 __all__ = [
     "StoredChatMessage",
     "ChatHistory",
+    "Project",
+    "ChatHistoryDB",
 ]

--- a/apps/chat/app/models/db_models.py
+++ b/apps/chat/app/models/db_models.py
@@ -1,0 +1,17 @@
+from sqlmodel import SQLModel, Field
+from typing import Optional
+from datetime import datetime
+import uuid
+
+class Project(SQLModel, table=True):
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    name: str
+
+class ChatHistoryDB(SQLModel, table=True):
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    project_id: str = Field(foreign_key="project.id")
+    messages: str
+    trace_id: Optional[str] = None
+    span_id: Optional[str] = None
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+

--- a/apps/chat/requirements.txt
+++ b/apps/chat/requirements.txt
@@ -9,3 +9,6 @@ opentelemetry-api
 opentelemetry-sdk
 opentelemetry-instrumentation-fastapi
 crewai
+sqlmodel
+psycopg2-binary
+alembic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,17 @@ dependencies = [
   "opentelemetry-sdk",
   "opentelemetry-instrumentation-fastapi",
   "PyYAML",
-  "notion-client"
+  "notion-client",
+  "sqlmodel",
+  "psycopg2-binary"
 ]
 
 [project.optional-dependencies]
 dev = [
   "pytest",
   "httpx",
-  "pytest-asyncio"
+  "pytest-asyncio",
+  "alembic"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- introduce SQLModel `Project` and `ChatHistoryDB`
- add database session handling via `core/db.py`
- switch API endpoints to work with the database
- initialize DB on startup and document migrations
- update dependencies for SQLModel and Alembic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685007eb3d2083308fcd0d607882fb25