### PR TITLE
Enforce non-empty ChatRequest messages

### DIFF
--- a/apps/chat/app/schemas/chat.py
+++ b/apps/chat/app/schemas/chat.py
@@ -14,7 +14,12 @@ class Message(BaseModel):
 class ChatRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     
-    messages: List[Message] = Field(..., examples=[[{"role": "user", "content": "Hi"}]])
+    messages: List[Message] = Field(
+        ...,
+        min_length=1,
+        examples=[[{"role": "user", "content": "Hi"}]],
+        description="At least one message must be provided.",
+    )
     user_api_key: Optional[str] = Field(None, alias="userApiKey", examples=["sk-..."])
 
 class ChatResponse(BaseModel):


### PR DESCRIPTION
## Summary
- require ChatRequest.messages to contain at least one item using `min_length=1`

## Testing
- `PYTHONPATH=apps/chat pytest apps/chat/tests` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6895966d4f9c8330aa81fde8f728ccfa