### PR TITLE
fix: correct crew config path

### DIFF
--- a/apps/chat/app/main.py
+++ b/apps/chat/app/main.py
@@ -55,7 +55,7 @@ def create_app() -> FastAPI:
    async def load_crew():
        enrich_context(event="startup_crew_start").info("Starting crew loading")
        try:
-           yaml_path = os.path.join(os.path.dirname(__file__), "infra_cluster.yaml")
+           yaml_path = os.path.join(os.path.dirname(__file__), "..", "crew-infra-cluster.yaml")
            if os.path.exists(yaml_path):
                app.state.crew = Crew.load(yaml_path)
                enrich_context(event="crew_loaded", file=yaml_path).info("Crew loaded from YAML")


### PR DESCRIPTION
## Summary
- load chat crew config from `crew-infra-cluster.yaml` relative to module location

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_6895997c967c8330922ac3d1b52d7351